### PR TITLE
Use assertEqual instead of assertEquals for Python 3.11 compatibility.

### DIFF
--- a/utest/test_config.py
+++ b/utest/test_config.py
@@ -39,19 +39,19 @@ class TestConfigurationEntries(unittest.TestCase):
         self._assert_entry(entry, '\r\n')
 
     def _assert_entry(self, entry, expected_value):
-        self.assertEquals(entry.value, expected_value)
+        self.assertEqual(entry.value, expected_value)
 
 
 class TestConfiguration(unittest.TestCase):
 
     def test_creating_configuration(self):
         cfg = Configuration(name=StringEntry(STRING_VALUE))
-        self.assertEquals(cfg.name, STRING_VALUE)
+        self.assertEqual(cfg.name, STRING_VALUE)
 
     def test_updating_configuration_values(self):
         cfg = Configuration(entry=StringEntry('other value'))
         cfg.update(entry=STRING_VALUE)
-        self.assertEquals(cfg.entry, STRING_VALUE)
+        self.assertEqual(cfg.entry, STRING_VALUE)
 
     def test_missing_config_item(self):
         self.assertRaises(ConfigurationException,

--- a/utest/test_library.py
+++ b/utest/test_library.py
@@ -26,10 +26,10 @@ class TestSSHLibraryConfiguration(unittest.TestCase):
 
     def _assert_config(self, cfg, timeout=3, newline='\n', prompt=None,
                        loglevel='INFO'):
-        self.assertEquals(cfg.timeout, timeout)
-        self.assertEquals(cfg.newline, newline)
-        self.assertEquals(cfg.prompt, prompt)
-        self.assertEquals(cfg.loglevel, loglevel)
+        self.assertEqual(cfg.timeout, timeout)
+        self.assertEqual(cfg.newline, newline)
+        self.assertEqual(cfg.prompt, prompt)
+        self.assertEqual(cfg.loglevel, loglevel)
 
 
 class TestSSHClientConfiguration(unittest.TestCase):
@@ -55,12 +55,12 @@ class TestSSHClientConfiguration(unittest.TestCase):
 
     def _assert_config(self, cfg, host=HOSTNAME, timeout=3, newline='\n',
                        prompt=None, port=22, term_type='vt100'):
-        self.assertEquals(cfg.host, host)
-        self.assertEquals(cfg.timeout, timeout)
-        self.assertEquals(cfg.newline, newline)
-        self.assertEquals(cfg.prompt, prompt)
-        self.assertEquals(cfg.term_type, term_type)
-        self.assertEquals(cfg.port, port)
+        self.assertEqual(cfg.host, host)
+        self.assertEqual(cfg.timeout, timeout)
+        self.assertEqual(cfg.newline, newline)
+        self.assertEqual(cfg.prompt, prompt)
+        self.assertEqual(cfg.term_type, term_type)
+        self.assertEqual(cfg.port, port)
 
 
 if __name__ == '__main__':

--- a/utest/test_scp.py
+++ b/utest/test_scp.py
@@ -19,7 +19,7 @@ class TestRemoteAndLocalPathResolution(unittest.TestCase):
             client = abstractclient.AbstractSFTPClient()
             client.is_dir = lambda x: False
             remote = client._get_put_file_destinations(src, dest, '/')[0]
-            self.assertEquals(remote, exp)
+            self.assertEqual(remote, exp)
 
     def test_get_file(self):
         data = [(['foo.txt'], '/home/test/', ['/home/test/foo.txt']),
@@ -31,7 +31,7 @@ class TestRemoteAndLocalPathResolution(unittest.TestCase):
         for src, dest, exp in data:
             client = abstractclient.AbstractSFTPClient()
             local = client._get_get_file_destinations(src, dest)
-            self.assertEquals(local, exp)
+            self.assertEqual(local, exp)
 
 
 class TestSSHClientGetMethod(unittest.TestCase):


### PR DESCRIPTION
The deprecated aliases were removed in Python 3.11 in python/cpython#28268