### PR TITLE
Remove paramiko hacks

### DIFF
--- a/src/SSHLibrary/library.py
+++ b/src/SSHLibrary/library.py
@@ -13,8 +13,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from __future__ import print_function
-
 import re
 
 from .logger import logger


### PR DESCRIPTION
Remove two paramiko hacks done in `client.py`. They both seem like very old workarounds and their functionality can be achieved through official paramiko APIs.

The first one set the banner timeout for paramiko `Transport` to 45 seconds. `banner_timeout` can be set in paramiko `SSHClient.connect` or with `Transport.banner_timeout`, I went with `connect` as it seems to be the expected way to do it. This might be a breaking change if someone is using the SSHLibrary `SSHClient.client` directly as then the timeout will be the default 15 seconds.

The second one is a workaround for `%` symbols in file paths reported in 2012: http://code.google.com/p/robotframework-sshlibrary/issues/detail?id=55 . It seems this has been fixed in paramiko in 2014 here: https://github.com/paramiko/paramiko/commit/6e9abc39cfff94e0dc36ebe6b939caa8d2eafee0 . As it has been fixed for so long I hope everyone moved on to newer paramiko and this is not needed anymore.

Also removed small remaining Python 2 compatibility.