### PR TITLE
Removes duplicate "list_files_in_dir" call.

### DIFF
--- a/src/SSHLibrary/library.py
+++ b/src/SSHLibrary/library.py
@@ -2193,7 +2193,6 @@ class SSHLibrary:
             files = self.current.list_files_in_dir(path, pattern, absolute)
         except SSHClientException as msg:
             raise RuntimeError(msg)
-        files = self.current.list_files_in_dir(path, pattern, absolute)
         self._log(
             "{0} file{1}:\n{2}".format(
                 len(files), plural_or_not(files), "\n".join(files)


### PR DESCRIPTION
The "list files in directory" keyword lists the files 2 times. Once inside the try.. catch and once after.
This is not necessary, introduces the risk of not catching SSHException and reduces performance.

This PR removes the second call.