### PR TITLE
Only use username from ssh config as default

### DIFF
--- a/atest/README.rst
+++ b/atest/README.rst
@@ -140,7 +140,7 @@ Additional OpenSSH configuration
     Testing pre-login banner
 
 
-- Add test_hostname, testkey_hostname and test_proxy_hostname in ``~/.ssh/config``
+- Add test_hostname, testkey_hostname, test_proxy_hostname and test_user_hostname in ``~/.ssh/config``
 
 ::
 
@@ -153,6 +153,10 @@ Additional OpenSSH configuration
 ::
 
     echo $'Host test_proxy_hostname\n    Hostname localhost\n    User test\n    Port 22\n    ProxyCommand ssh -W %h:%p testkey_hostname\n' >> ~/.ssh/config
+
+::
+
+    echo $'Host test_user_hostname\n    Hostname localhost\n    User nonexisting\n    Port 22\n' >> ~/.ssh/config
 
 
 Setup for Docker

--- a/atest/login.robot
+++ b/atest/login.robot
@@ -70,6 +70,10 @@ Login With Public Key Using Config File
     [Setup]    Open Connection    ${TESTKEY_HOSTNAME}    prompt=${PROMPT}
     Login With Public Key    read_config=True
 
+Login With Specified User Differing From Config File
+    [Setup]    Open Connection    ${TEST_USER_HOSTNAME}    prompt=${PROMPT}
+    Login    ${USERNAME}    ${PASSWORD}    read_config=True
+
 Login With No Password
     [Setup]    Open Connection    ${HOST}    prompt=${PROMPT}
     Login    ${USERNAME_NOPASSWD}

--- a/atest/resources/common.robot
+++ b/atest/resources/common.robot
@@ -18,6 +18,7 @@ ${KEY}                      ${KEY DIR}${/}id_rsa
 ${TEST_HOSTNAME}            test_hostname
 ${TESTKEY_HOSTNAME}         testkey_hostname
 ${TEST_PROXY_HOSTNAME}      test_proxy_hostname
+${TEST_USER_HOSTNAME}       test_user_hostname
 ${EMPTY_STRING}             \
 
 

--- a/src/SSHLibrary/client.py
+++ b/src/SSHLibrary/client.py
@@ -884,8 +884,10 @@ class SSHClient(object):
                read_config=False, jumphost_connection=None, keep_alive_interval=None, disabled_algorithms=None):
         if read_config:
             hostname = self.config.host
-            self.config.host, username, self.config.port, proxy_cmd = \
+            self.config.host, username_from_config, self.config.port, proxy_cmd = \
                 self._read_login_ssh_config(hostname, username, self.config.port, proxy_cmd)
+            if not username or username == b'None':
+                username = username_from_config
 
         sock_tunnel = None
 


### PR DESCRIPTION
If a username is specified in the `Login` keyword, it should supersede the username from the ssh config.