### PR TITLE
`Write` fails when reading the console runs in decoding error

### DIFF
--- a/.github/workflows/acceptence_tests.yml
+++ b/.github/workflows/acceptence_tests.yml
@@ -57,7 +57,7 @@ jobs:
           ssh-add atest/testdata/keyfiles/id_rsa
       - name: Run tests
         run: |
-          robot -d results-${{ matrix.python-version }} -e no-gh-actions -b console.log -x xunit.xml atest
+          robot -d results-${{ matrix.python-version }} -e no-gh-actions -b console.log -x xunit.xml -L DEBUG:INFO atest
       - uses: actions/upload-artifact@v4
         if: success() || failure()
         with:

--- a/.github/workflows/acceptence_tests.yml
+++ b/.github/workflows/acceptence_tests.yml
@@ -57,7 +57,7 @@ jobs:
           ssh-add atest/testdata/keyfiles/id_rsa
       - name: Run tests
         run: |
-          robot -d results-${{ matrix.python-version }} -e no-gh-actions -b console.log -x xunit.xml -L DEBUG:INFO atest
+          robot -d results-${{ matrix.python-version }} -e no-gh-actions -b console.log -x xunit.xml -L TRACE:INFO atest
       - uses: actions/upload-artifact@v4
         if: success() || failure()
         with:

--- a/atest/write_and_read/other_writes_and_reads.robot
+++ b/atest/write_and_read/other_writes_and_reads.robot
@@ -101,7 +101,7 @@ Configure Session Width And Height
     ${conn} =    Get Connection    1
     Should Be Equal As Integers    ${conn.height}    48
     Should Be Equal As Integers    ${conn.width}    160
-    Write Bare    stty size    add_newline=True
+    Write    stty size
     ${output} =    Read Until Prompt
     Should Contain    ${output}    48 160
     [Teardown]    Set Client Configuration    height=24    width=80

--- a/atest/write_and_read/other_writes_and_reads.robot
+++ b/atest/write_and_read/other_writes_and_reads.robot
@@ -112,6 +112,11 @@ Read Until With Encoding Errors On Strict
     ...    This is not the exact expected behavior of the test title, but for now good enough.
     TRY
         Write    cat ${REMOTE TEST ROOT}/${CORRUPTED FILE NAME}
+    EXCEPT
+        SKIP    Could not test READ UNTIL, as WRITE command is flaky in failing fast with corrupted data.
+    END
+
+    TRY
         Read Until    We expect this to fail, if Write did not fail already
         Fail    WRITE or READ UNTIL should have failed with expected error
     EXCEPT    *codec can't decode byte*    type=GLOB    AS    ${error_message}

--- a/atest/write_and_read/other_writes_and_reads.robot
+++ b/atest/write_and_read/other_writes_and_reads.robot
@@ -102,27 +102,12 @@ Configure Session Width And Height
     [Teardown]    Set Client Configuration    height=24    width=80
 
 Read Until With Encoding Errors On Strict
-    [Documentation]    This test is expected to fail because the file contains invalid UTF-8 characters.
-    ...
-    ...    For later debugging:
-    ...
-    ...    Originally the READ UNTIL keyword would fail with a UnicodeDecodeError, but due to some reason, the WRITE command has a chance of failing directly.
-    ...    Since this is kind of the expected behavior, we now also allow the WRITE command to fail with the same expected error message as the Read.
-    ...
-    ...    This is not the exact expected behavior of the test title, but for now good enough.
-    GROUP    Call "cat" of corrupted file
-        TRY
-            Write    cat ${REMOTE TEST ROOT}/${CORRUPTED FILE NAME}
-        EXCEPT
-            SKIP    Could not test READ UNTIL, as WRITE command is flaky in failing fast with corrupted data.
-        END
-    END
-
+    Write    cat ${REMOTE TEST ROOT}/${CORRUPTED FILE NAME}
     GROUP    Read output from "cat" command
         TRY
             # "Hello" is at the end of the corrupted file
             Read Until    Hello
-            Fail    WRITE or READ UNTIL should have failed with expected error
+            Fail    READ UNTIL should have failed with expected error
         EXCEPT    *codec can't decode byte*    type=GLOB    AS    ${error_message}
             Log    Write command failed with expected error: ${error_message}
         END

--- a/atest/write_and_read/other_writes_and_reads.robot
+++ b/atest/write_and_read/other_writes_and_reads.robot
@@ -102,8 +102,12 @@ Configure Session Width And Height
     [Teardown]    Set Client Configuration    height=24    width=80
 
 Read Until With Encoding Errors On Strict
-    Write    cat ${REMOTE TEST ROOT}/${CORRUPTED FILE NAME}
-    Run Keyword And Expect Error    *codec can't decode byte*    Read Until    Hello
+    TRY
+        Write    cat ${REMOTE TEST ROOT}/${CORRUPTED FILE NAME}
+        Read Until    We expect this to fail, if Write did not fail already
+    EXCEPT    *codec can't decode byte*    type=GLOB    AS    ${error_message}
+        Log    Write command failed with expected error: ${error_message}
+    END
 
 Read Until With Encoding Errors On Replace
     Set Client Configuration    encoding_errors=replace

--- a/atest/write_and_read/other_writes_and_reads.robot
+++ b/atest/write_and_read/other_writes_and_reads.robot
@@ -23,7 +23,7 @@ Write And Read Until Prompt
     Should Contain    ${output}    Hello Mr. Ääkkönen
 
 Write And Read Until Regexp
-    Write Bare    ${REMOTE TEST ROOT}/${INTERACTIVE TEST SCRIPT NAME}
+    Write    ${REMOTE TEST ROOT}/${INTERACTIVE TEST SCRIPT NAME}
     ${output} =    Read Until Regexp    Give.*\\?
     Should Contain    ${output}    Give your name?
     Write Bare    Mr. Ääkkönen    add_newline=True
@@ -83,14 +83,14 @@ Write Until Expected Output In Case Of Timeout
     [Teardown]    Execute Command    rm -f ${COUNTER NAME}
 
 Read Until Prompt With Strip Prompt
-    Write Bare    echo This is a test
+    Write Bare    echo This is a test    add_newline=True
     ${output} =    Read Until Prompt    strip_prompt=True
     Should Contain    ${output}    This is a test
     Should Not Contain    ${output}    ${PROMPT}
 
 Read Until REGEXP Prompt With Strip Prompt
     Set Client Configuration    prompt=REGEXP:[#$]
-    Write Bare    echo This is a test
+    Write Bare    echo This is a test    add_newline=True
     ${output} =    Read Until Prompt    strip_prompt=True
     Should Contain    ${output}    This is a test
     Should Not Match Regexp    ${output}    [#$]
@@ -101,7 +101,7 @@ Configure Session Width And Height
     ${conn} =    Get Connection    1
     Should Be Equal As Integers    ${conn.height}    48
     Should Be Equal As Integers    ${conn.width}    160
-    Write    stty size
+    Write Bare    stty size    add_newline=True
     ${output} =    Read Until Prompt
     Should Contain    ${output}    48 160
     [Teardown]    Set Client Configuration    height=24    width=80
@@ -133,6 +133,6 @@ Read Until With Encoding Errors On Ignore
 Read Until With Encoding Errors Set In Open Connection
     [Setup]    Run Keywords    Open Connection    ${HOST}    prompt=${PROMPT}    encoding_errors=replace    AND
     ...    Login    ${USERNAME}    ${PASSWORD}
-    Write Bare    cat ${REMOTE TEST ROOT}/${CORRUPTED FILE NAME}
+    Write Bare    cat ${REMOTE TEST ROOT}/${CORRUPTED FILE NAME}    add_newline=True
     ${output} =    Read Until    Hello
     Should Contain    ${output}    Hello

--- a/atest/write_and_read/other_writes_and_reads.robot
+++ b/atest/write_and_read/other_writes_and_reads.robot
@@ -17,8 +17,8 @@ Write And Read Until
     Should Contain    ${output}    Hello Mr. Ääkkönen
 
 Write And Read Until Prompt
-    Write Bare    ${REMOTE TEST ROOT}/${INTERACTIVE TEST SCRIPT NAME}
-    Write Bare    Mr. Ääkkönen
+    Write Bare    ${REMOTE TEST ROOT}/${INTERACTIVE TEST SCRIPT NAME}    add_newline=True
+    Write Bare    Mr. Ääkkönen    add_newline=True
     ${output} =    Read Until Prompt
     Should Contain    ${output}    Hello Mr. Ääkkönen
 
@@ -26,14 +26,14 @@ Write And Read Until Regexp
     Write Bare    ${REMOTE TEST ROOT}/${INTERACTIVE TEST SCRIPT NAME}
     ${output} =    Read Until Regexp    Give.*\\?
     Should Contain    ${output}    Give your name?
-    Write Bare    Mr. Ääkkönen
+    Write Bare    Mr. Ääkkönen    add_newline=True
     Comment    Prompt needs to be escaped because it might be $
     ${output} =    Read Until Regexp    (?s).*\\${PROMPT}
     Should Contain    ${output}    Hello Mr. Ääkkönen
     Should End With    ${output}    ${PROMPT}
 
 Write Non-String
-    Write Bare    ${1}
+    Write    ${1}
     ${output} =    Read Until Prompt
     Should Contain    ${output}    1
 
@@ -42,25 +42,30 @@ Write Bare Non-String
     ${output} =    Read Until Prompt
     Should Contain    ${output}    False
 
+Write Bare Add New Line Non-String
+    Write Bare    ${False}    add_newline=True
+    ${output} =    Read Until Prompt
+    Should Contain    ${output}    False
+
 Write In Case Of Timeout
-    Write Bare    Foo Bar And Some Other
+    Write Bare    Foo Bar And Some Other    add_newline=True
     Set Client Configuration    timeout=1
     ${status}    ${error} =    Run Keyword And Ignore Error
     ...    Read Until    This is not found
     Should Start With    ${error}    No match found for 'This is not found' in 1 second
 
 Write Returning Stderr
-    Write Bare    ${REMOTE TEST ROOT}/${INTERACTIVE TEST SCRIPT NAME}
+    Write    ${REMOTE TEST ROOT}/${INTERACTIVE TEST SCRIPT NAME}
     Read Until    Give your name?
-    Write Bare    Error
+    Write Bare    Error    add_newline=True
     ${output} =    Read Until    ${PROMPT}
     Should Contain    ${output}    Hello Error
     Should Contain    ${output}    This is Error
 
 Write Bare And Read Until
-    Write Bare    ${REMOTE TEST ROOT}/${INTERACTIVE TEST SCRIPT NAME}\n
+    Write Bare    ${REMOTE TEST ROOT}/${INTERACTIVE TEST SCRIPT NAME}    add_newline=True
     ${output} =    Read Until    name?
-    Write Bare    Mr. Ääkkönen\n
+    Write Bare    Mr. Ääkkönen    add_newline=True
     ${output2} =    Read Until Prompt
     Should Contain    ${output}    Give your name?
     Should Contain    ${output2}    Hello Mr. Ääkkönen
@@ -96,13 +101,13 @@ Configure Session Width And Height
     ${conn} =    Get Connection    1
     Should Be Equal As Integers    ${conn.height}    48
     Should Be Equal As Integers    ${conn.width}    160
-    Write Bare    stty size
+    Write    stty size
     ${output} =    Read Until Prompt
     Should Contain    ${output}    48 160
     [Teardown]    Set Client Configuration    height=24    width=80
 
 Read Until With Encoding Errors On Strict
-    Write Bare    cat ${REMOTE TEST ROOT}/${CORRUPTED FILE NAME}
+    Write Bare    cat ${REMOTE TEST ROOT}/${CORRUPTED FILE NAME}    add_newline=True
     GROUP    Read output from "cat" command
         TRY
             # "Hello" is at the end of the corrupted file
@@ -115,13 +120,13 @@ Read Until With Encoding Errors On Strict
 
 Read Until With Encoding Errors On Replace
     Set Client Configuration    encoding_errors=replace
-    Write Bare    cat ${REMOTE TEST ROOT}/${CORRUPTED FILE NAME}
+    Write Bare    cat ${REMOTE TEST ROOT}/${CORRUPTED FILE NAME}    add_newline=True
     ${output} =    Read Until    Hello
     Should Contain    ${output}    Hello
 
 Read Until With Encoding Errors On Ignore
     Set Client Configuration    encoding_errors=ignore
-    Write Bare    cat ${REMOTE TEST ROOT}/${CORRUPTED FILE NAME}
+    Write Bare    cat ${REMOTE TEST ROOT}/${CORRUPTED FILE NAME}    add_newline=True
     ${output} =    Read Until    Hello
     Should Contain    ${output}    Hello
 

--- a/atest/write_and_read/other_writes_and_reads.robot
+++ b/atest/write_and_read/other_writes_and_reads.robot
@@ -110,17 +110,22 @@ Read Until With Encoding Errors On Strict
     ...    Since this is kind of the expected behavior, we now also allow the WRITE command to fail with the same expected error message as the Read.
     ...
     ...    This is not the exact expected behavior of the test title, but for now good enough.
-    TRY
-        Write    cat ${REMOTE TEST ROOT}/${CORRUPTED FILE NAME}
-    EXCEPT
-        SKIP    Could not test READ UNTIL, as WRITE command is flaky in failing fast with corrupted data.
+    GROUP    Call "cat" of corrupted file
+        TRY
+            Write    cat ${REMOTE TEST ROOT}/${CORRUPTED FILE NAME}
+        EXCEPT
+            SKIP    Could not test READ UNTIL, as WRITE command is flaky in failing fast with corrupted data.
+        END
     END
 
-    TRY
-        Read Until    We expect this to fail, if Write did not fail already
-        Fail    WRITE or READ UNTIL should have failed with expected error
-    EXCEPT    *codec can't decode byte*    type=GLOB    AS    ${error_message}
-        Log    Write command failed with expected error: ${error_message}
+    GROUP    Read output from "cat" command
+        TRY
+            # "Hello" is at the end of the corrupted file
+            Read Until    Hello
+            Fail    WRITE or READ UNTIL should have failed with expected error
+        EXCEPT    *codec can't decode byte*    type=GLOB    AS    ${error_message}
+            Log    Write command failed with expected error: ${error_message}
+        END
     END
 
 Read Until With Encoding Errors On Replace

--- a/atest/write_and_read/other_writes_and_reads.robot
+++ b/atest/write_and_read/other_writes_and_reads.robot
@@ -17,23 +17,23 @@ Write And Read Until
     Should Contain    ${output}    Hello Mr. Ääkkönen
 
 Write And Read Until Prompt
-    Write    ${REMOTE TEST ROOT}/${INTERACTIVE TEST SCRIPT NAME}
-    Write    Mr. Ääkkönen
+    Write Bare    ${REMOTE TEST ROOT}/${INTERACTIVE TEST SCRIPT NAME}
+    Write Bare    Mr. Ääkkönen
     ${output} =    Read Until Prompt
     Should Contain    ${output}    Hello Mr. Ääkkönen
 
 Write And Read Until Regexp
-    Write    ${REMOTE TEST ROOT}/${INTERACTIVE TEST SCRIPT NAME}
+    Write Bare    ${REMOTE TEST ROOT}/${INTERACTIVE TEST SCRIPT NAME}
     ${output} =    Read Until Regexp    Give.*\\?
     Should Contain    ${output}    Give your name?
-    Write    Mr. Ääkkönen
+    Write Bare    Mr. Ääkkönen
     Comment    Prompt needs to be escaped because it might be $
     ${output} =    Read Until Regexp    (?s).*\\${PROMPT}
     Should Contain    ${output}    Hello Mr. Ääkkönen
     Should End With    ${output}    ${PROMPT}
 
 Write Non-String
-    Write    ${1}
+    Write Bare    ${1}
     ${output} =    Read Until Prompt
     Should Contain    ${output}    1
 
@@ -43,16 +43,16 @@ Write Bare Non-String
     Should Contain    ${output}    False
 
 Write In Case Of Timeout
-    Write    Foo Bar And Some Other
+    Write Bare    Foo Bar And Some Other
     Set Client Configuration    timeout=1
     ${status}    ${error} =    Run Keyword And Ignore Error
     ...    Read Until    This is not found
     Should Start With    ${error}    No match found for 'This is not found' in 1 second
 
 Write Returning Stderr
-    Write    ${REMOTE TEST ROOT}/${INTERACTIVE TEST SCRIPT NAME}
+    Write Bare    ${REMOTE TEST ROOT}/${INTERACTIVE TEST SCRIPT NAME}
     Read Until    Give your name?
-    Write    Error
+    Write Bare    Error
     ${output} =    Read Until    ${PROMPT}
     Should Contain    ${output}    Hello Error
     Should Contain    ${output}    This is Error
@@ -78,14 +78,14 @@ Write Until Expected Output In Case Of Timeout
     [Teardown]    Execute Command    rm -f ${COUNTER NAME}
 
 Read Until Prompt With Strip Prompt
-    Write    echo This is a test
+    Write Bare    echo This is a test
     ${output} =    Read Until Prompt    strip_prompt=True
     Should Contain    ${output}    This is a test
     Should Not Contain    ${output}    ${PROMPT}
 
 Read Until REGEXP Prompt With Strip Prompt
     Set Client Configuration    prompt=REGEXP:[#$]
-    Write    echo This is a test
+    Write Bare    echo This is a test
     ${output} =    Read Until Prompt    strip_prompt=True
     Should Contain    ${output}    This is a test
     Should Not Match Regexp    ${output}    [#$]
@@ -96,13 +96,13 @@ Configure Session Width And Height
     ${conn} =    Get Connection    1
     Should Be Equal As Integers    ${conn.height}    48
     Should Be Equal As Integers    ${conn.width}    160
-    Write    stty size
+    Write Bare    stty size
     ${output} =    Read Until Prompt
     Should Contain    ${output}    48 160
     [Teardown]    Set Client Configuration    height=24    width=80
 
 Read Until With Encoding Errors On Strict
-    Write    cat ${REMOTE TEST ROOT}/${CORRUPTED FILE NAME}
+    Write Bare    cat ${REMOTE TEST ROOT}/${CORRUPTED FILE NAME}
     GROUP    Read output from "cat" command
         TRY
             # "Hello" is at the end of the corrupted file
@@ -115,19 +115,19 @@ Read Until With Encoding Errors On Strict
 
 Read Until With Encoding Errors On Replace
     Set Client Configuration    encoding_errors=replace
-    Write    cat ${REMOTE TEST ROOT}/${CORRUPTED FILE NAME}
+    Write Bare    cat ${REMOTE TEST ROOT}/${CORRUPTED FILE NAME}
     ${output} =    Read Until    Hello
     Should Contain    ${output}    Hello
 
 Read Until With Encoding Errors On Ignore
     Set Client Configuration    encoding_errors=ignore
-    Write    cat ${REMOTE TEST ROOT}/${CORRUPTED FILE NAME}
+    Write Bare    cat ${REMOTE TEST ROOT}/${CORRUPTED FILE NAME}
     ${output} =    Read Until    Hello
     Should Contain    ${output}    Hello
 
 Read Until With Encoding Errors Set In Open Connection
     [Setup]    Run Keywords    Open Connection    ${HOST}    prompt=${PROMPT}    encoding_errors=replace    AND
     ...    Login    ${USERNAME}    ${PASSWORD}
-    Write    cat ${REMOTE TEST ROOT}/${CORRUPTED FILE NAME}
+    Write Bare    cat ${REMOTE TEST ROOT}/${CORRUPTED FILE NAME}
     ${output} =    Read Until    Hello
     Should Contain    ${output}    Hello

--- a/atest/write_and_read/other_writes_and_reads.robot
+++ b/atest/write_and_read/other_writes_and_reads.robot
@@ -102,9 +102,18 @@ Configure Session Width And Height
     [Teardown]    Set Client Configuration    height=24    width=80
 
 Read Until With Encoding Errors On Strict
+    [Documentation]    This test is expected to fail because the file contains invalid UTF-8 characters.
+    ...
+    ...    For later debugging:
+    ...
+    ...    Originally the READ UNTIL keyword would fail with a UnicodeDecodeError, but due to some reason, the WRITE command has a chance of failing directly.
+    ...    Since this is kind of the expected behavior, we now also allow the WRITE command to fail with the same expected error message as the Read.
+    ...
+    ...    This is not the exact expected behavior of the test title, but for now good enough.
     TRY
         Write    cat ${REMOTE TEST ROOT}/${CORRUPTED FILE NAME}
         Read Until    We expect this to fail, if Write did not fail already
+        Fail    WRITE or READ UNTIL should have failed with expected error
     EXCEPT    *codec can't decode byte*    type=GLOB    AS    ${error_message}
         Log    Write command failed with expected error: ${error_message}
     END

--- a/src/SSHLibrary/library.py
+++ b/src/SSHLibrary/library.py
@@ -1579,6 +1579,8 @@ class SSHLibrary:
         The written ``text`` is logged. ``loglevel`` can be used to override
         the default `log level`.
 
+        If the written text cannot be read from shell, `None` is returned.
+
         Example:
         | ${written}=          | `Write`         | su                         |
         | `Should Contain`     | ${written}      | su                         | # Returns the consumed output  |
@@ -1596,7 +1598,7 @@ class SSHLibrary:
         try:
             return self._read_and_log(loglevel, self.current.read_until_newline)
         except Exception as e:
-            logger.error(e)
+            logger.warn(e)
             return None
 
     @keyword(tags=("command",))

--- a/src/SSHLibrary/library.py
+++ b/src/SSHLibrary/library.py
@@ -1572,8 +1572,6 @@ class SSHLibrary:
     def write(self, text, loglevel=None):
         """Writes the given ``text`` on the remote machine and appends a newline.
 
-        Appended `newline` can be configured.
-
         This keyword returns and consumes the written ``text``
         (including the appended newline) from the server output. See the
         `Interactive shells` section for more information.
@@ -1608,12 +1606,14 @@ class SSHLibrary:
         Unlike `Write`, this keyword returns and consumes nothing. See the
         `Interactive shells` section for more information.
 
+        Appended `newline` can be configured with `add_newline`.
+
         Example:
-        | `Write Bare`     | su\\n            |
+        | `Write Bare`     | su\\n            | # or instead of \\n: add_newline=True
         | ${output}=       | `Read`           |
         | `Should Contain` | ${output}        | su                         | # Was not consumed from output |
         | `Should Contain` | ${output}        | Password:                  |
-        | `Write Bare`     | invalidpasswd\\n |
+        | `Write Bare`     | invalidpasswd\\n | # or instead of \\n: add_newline=True
         | ${output}=       | `Read`           |
         | `Should Contain` | ${output}        | su: Authentication failure |
 

--- a/src/SSHLibrary/library.py
+++ b/src/SSHLibrary/library.py
@@ -642,7 +642,8 @@ class SSHLibrary:
         | # Check myserver.log for detailed debug information   |
         """
         if SSHClient.enable_logging(logfile):
-            self._log(f'SSH log is written to <a href="{logfile}">file</a>.', "HTML")
+            self._log(
+                f'SSH log is written to <a href="{logfile}">file</a>.', "HTML")
 
     @keyword(tags=("connection",))
     def open_connection(
@@ -1356,8 +1357,10 @@ class SSHLibrary:
         if not is_truthy(sudo):
             self._log(f"Executing command '{command}'.", self._config.loglevel)
         else:
-            self._log(f"Executing command 'sudo {command}'.", self._config.loglevel)
-        opts = self._legacy_output_options(return_stdout, return_stderr, return_rc)
+            self._log(
+                f"Executing command 'sudo {command}'.", self._config.loglevel)
+        opts = self._legacy_output_options(
+            return_stdout, return_stderr, return_rc)
         stdout, stderr, rc = self.current.execute_command(
             command,
             sudo,
@@ -1424,7 +1427,8 @@ class SSHLibrary:
         if not is_truthy(sudo):
             self._log(f"Starting command '{command}'.", self._config.loglevel)
         else:
-            self._log(f"Starting command 'sudo {command}'.", self._config.loglevel)
+            self._log(
+                f"Starting command 'sudo {command}'.", self._config.loglevel)
         if self.current.config.index not in self._last_commands.keys():
             self._last_commands[self.current.config.index] = command
         else:
@@ -1493,9 +1497,11 @@ class SSHLibrary:
             f"Reading output of command '{self._last_commands.get(self.current.config.index)}'.",
             self._config.loglevel,
         )
-        opts = self._legacy_output_options(return_stdout, return_stderr, return_rc)
+        opts = self._legacy_output_options(
+            return_stdout, return_stderr, return_rc)
         try:
-            stdout, stderr, rc = self.current.read_command_output(timeout=timeout)
+            stdout, stderr, rc = self.current.read_command_output(
+                timeout=timeout)
         except SSHClientException as msg:
             raise RuntimeError(msg)
         return self._return_command_output(stdout, stderr, rc, *opts)
@@ -1549,7 +1555,8 @@ class SSHLibrary:
     def _return_command_output(
         self, stdout, stderr, rc, return_stdout, return_stderr, return_rc
     ):
-        self._log(f"Command exited with return code {rc}.", self._config.loglevel)
+        self._log(
+            f"Command exited with return code {rc}.", self._config.loglevel)
         ret = []
         if is_truthy(return_stdout):
             ret.append(stdout.rstrip("\n"))
@@ -1587,7 +1594,12 @@ class SSHLibrary:
         See also `Write Bare`.
         """
         self._write(text, add_newline=True)
-        return self._read_and_log(loglevel, self.current.read_until_newline)
+
+        try:
+            return self._read_and_log(loglevel, self.current.read_until_newline)
+        except Exception as e:
+            logger.error(e)
+            return None
 
     @keyword(tags=("command",))
     def write_bare(self, text):
@@ -2206,7 +2218,8 @@ class SSHLibrary:
     def list_directories_in_directory(self, path, pattern=None, absolute=False):
         """A wrapper for `List Directory` that returns only directories."""
         try:
-            dirs = self.current.list_dirs_in_dir(path, pattern, is_truthy(absolute))
+            dirs = self.current.list_dirs_in_dir(
+                path, pattern, is_truthy(absolute))
         except SSHClientException as msg:
             raise RuntimeError(msg)
         self._log(

--- a/src/SSHLibrary/library.py
+++ b/src/SSHLibrary/library.py
@@ -1602,7 +1602,7 @@ class SSHLibrary:
             return None
 
     @keyword(tags=("command",))
-    def write_bare(self, text):
+    def write_bare(self, text, add_newline=False):
         """Writes the given ``text`` on the remote machine without appending a newline.
 
         Unlike `Write`, this keyword returns and consumes nothing. See the
@@ -1619,7 +1619,7 @@ class SSHLibrary:
 
         See also `Write`.
         """
-        self._write(text)
+        self._write(text, add_newline)
 
     def _write(self, text, add_newline=False):
         try:


### PR DESCRIPTION
related to #472 

At some point the behavior of `write` keyword had been changed and the `write bare` keyword had been introduced. However the test cases had not been fixed.

The `write` keyword fails for testcases with encoding erros printed on the commandline, because the "new" behavior introduced reading the result from the commandline.

This PR now fails silently if the reading from the commandline fails and returns `None`.

Closes #465 