### PR TITLE
Add pyproject.toml to fix pip install deprecation (fixes #480)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,46 @@
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "robotframework-sshlibrary"
+dynamic = ["version"]
+description = "Robot Framework test library for SSH and SFTP"
+readme = "README.rst"
+license = "Apache-2.0"
+requires-python = ">=3.8"
+authors = [
+    {name = "Markus Stahl", email = "markus.i.sverige@gmail.com"},
+]
+keywords = ["robotframework", "testing", "testautomation", "ssh", "sftp"]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Testing",
+    "Framework :: Robot Framework",
+    "Framework :: Robot Framework :: Library",
+]
+dependencies = [
+    "robotframework>=5.0",
+    "paramiko>=1.15.3",
+    "scp>=0.13.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/MarketSquare/SSHLibrary"
+Documentation = "https://marketsquare.github.io/SSHLibrary/SSHLibrary.html"
+Repository = "https://github.com/MarketSquare/SSHLibrary"
+Issues = "https://github.com/MarketSquare/SSHLibrary/issues"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.dynamic]
+version = {attr = "SSHLibrary.version.VERSION"}

--- a/setup.py
+++ b/setup.py
@@ -1,43 +1,10 @@
 #!/usr/bin/env python
+"""Backward-compatible setup.py shim.
 
-import re
-from os.path import abspath, dirname, join
+All project metadata has been moved to pyproject.toml.
+This file is kept only for compatibility with legacy tooling
+(e.g. `python setup.py install`).
+"""
 from setuptools import setup
 
-CURDIR = dirname(abspath(__file__))
-REQUIREMENTS = ["robotframework >= 5.0", "paramiko >= 1.15.3", "scp >= 0.13.0"]
-with open(join(CURDIR, "src", "SSHLibrary", "version.py")) as f:
-    VERSION = re.search("\nVERSION = '(.*)'", f.read()).group(1)
-with open(join(CURDIR, "README.rst")) as f:
-    DESCRIPTION = f.read()
-CLASSIFIERS = """
-Development Status :: 5 - Production/Stable
-License :: OSI Approved :: Apache Software License
-Operating System :: OS Independent
-Programming Language :: Python
-Programming Language :: Python :: 3.8
-Programming Language :: Python :: 3.9
-Programming Language :: Python :: 3.10
-Programming Language :: Python :: 3.11
-Programming Language :: Python :: 3.12
-Topic :: Software Development :: Testing
-Framework :: Robot Framework
-Framework :: Robot Framework :: Library
-""".strip().splitlines()
-
-setup(
-    name="robotframework-sshlibrary",
-    version=VERSION,
-    description="Robot Framework test library for SSH and SFTP",
-    long_description=DESCRIPTION,
-    author="Markus Stahl",
-    author_email="markus.i.sverige@gmail.com",
-    url="https://github.com/MarketSquare/SSHLibrary",
-    license="Apache License 2.0",
-    keywords="robotframework testing testautomation ssh sftp",
-    platforms="any",
-    classifiers=CLASSIFIERS,
-    install_requires=REQUIREMENTS,
-    package_dir={"": "src"},
-    packages=["SSHLibrary"],
-)
+setup()


### PR DESCRIPTION
  Migrate build configuration from setup.py to pyproject.toml (PEP 517/621).
  This resolves the pip deprecation warning and prevents pip 25.3 from blocking installs.

  Changes:
  - Add pyproject.toml with all project metadata
  - Slim setup.py to backward-compatible shim
  - Add Python 3.13 to classifiers
  - Use PEP 639 license expression (Apache-2.0)

  Testing:
  - Verified `python -m build` produces both sdist and wheel
  - Verified wheel installs correctly with all dependencies resolved
  - Version reads correctly from `SSHLibrary.version.VERSION`