### PR TITLE
Update Python versions in acceptance tests workflow

### DIFF
--- a/.github/workflows/acceptence_tests.yml
+++ b/.github/workflows/acceptence_tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Remove outdated 3.8 and 3.9 and add 3.13 and 3.14