### PR TITLE
Add VS Code devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,59 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        bash-completion \
+        ca-certificates \
+        gcc \
+        git \
+        language-pack-en \
+        libffi-dev \
+        locales \
+        make \
+        musl-dev \
+        net-tools \
+        openssh-client \
+        openssh-server \
+        python3 \
+        python3-pip \
+        python3-venv \
+        sudo \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen \
+    && locale-gen
+
+ENV LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    LC_ALL=en_US.UTF-8
+
+RUN python3 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:${PATH}"
+
+RUN mkdir -p /run/sshd \
+    && useradd --create-home --shell /bin/bash test-nopasswd \
+    && passwd --delete test-nopasswd \
+    && echo "PermitEmptyPasswords yes" >> /etc/ssh/sshd_config \
+    && useradd --create-home --shell /bin/bash test \
+    && (echo 'test'; echo 'test') | passwd test \
+    && adduser test sudo \
+    && echo 'test   ALL=(ALL:ALL) PASSWD:ALL' > /etc/sudoers.d/passworded \
+    && chmod 0440 /etc/sudoers.d/passworded \
+    && useradd --create-home --shell /bin/bash testkey \
+    && echo "export PS1='\\u@\\h \\W \\$ '" >> /home/test/.bashrc \
+    && echo "export PS1='\\u@\\h \\W \\$ '" >> /home/testkey/.bashrc \
+    && sudo -u testkey mkdir -p /home/testkey/.ssh \
+    && sudo -u testkey ssh-keygen -f /home/testkey/.ssh/id_rsa -t rsa -N '' \
+    && sudo -u testkey cp /home/testkey/.ssh/id_rsa.pub /home/testkey/.ssh/authorized_keys \
+    && chmod 700 /home/testkey/.ssh \
+    && chmod 600 /home/testkey/.ssh/authorized_keys \
+    && chmod 644 /home/testkey/.ssh/id_rsa \
+    && echo 'Testing pre-login banner' > /etc/ssh/sshd-banner \
+    && echo 'Banner /etc/ssh/sshd-banner' >> /etc/ssh/sshd_config \
+    && echo 'Subsystem subsys echo "Subsystem invoked."' >> /etc/ssh/sshd_config \
+    && mkdir -p /root/.ssh \
+    && printf 'Host test_hostname\n    Hostname localhost\n' >> /root/.ssh/config
+
+CMD ["sleep", "infinity"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+{
+  "name": "SSHLibrary development",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "workspaceFolder": "/SSHLibrary",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/SSHLibrary,type=bind,consistency=cached",
+  "postCreateCommand": "python -m pip install --upgrade pip && python -m pip install -e . -r requirements-dev.txt && cp /home/testkey/.ssh/id_rsa atest/testdata/keyfiles/id_rsa",
+  "postStartCommand": "service ssh start",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "robocorp.robotframework-lsp"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "/opt/venv/bin/python"
+      }
+    }
+  }
+}

--- a/atest/README.rst
+++ b/atest/README.rst
@@ -155,6 +155,23 @@ Additional OpenSSH configuration
     echo $'Host test_proxy_hostname\n    Hostname localhost\n    User test\n    Port 22\n    ProxyCommand ssh -W %h:%p testkey_hostname\n' >> ~/.ssh/config
 
 
+Setup for VS Code Dev Containers
+================================
+
+The repository includes a Dev Container configuration for contributors who want
+an out-of-box Linux development environment in VS Code. Open the repository in
+VS Code and run ``Dev Containers: Reopen in Container``. The container installs
+SSHLibrary in editable mode, starts an OpenSSH server when the container starts,
+and prepares the ``test``, ``test-nopasswd``, and ``testkey`` accounts used by
+the acceptance tests.
+
+After the container has started, acceptance tests can be run from the repository
+root with:
+
+::
+
+    python3 atest/run.py .
+
 Setup for Docker
 ================
 First go into the ``docker`` folder and build a SSHLibrary image that will be based on your repository:


### PR DESCRIPTION
## Summary

Fixes #452 by adding a VS Code Dev Container setup for SSHLibrary contributors.

## Changes

- Add `.devcontainer/devcontainer.json` and a matching Dockerfile.
- Prepare the same SSH users/settings used by the acceptance test environment (`test`, `test-nopasswd`, `testkey`, banner, custom subsystem).
- Install SSHLibrary into an isolated `/opt/venv` during container creation and start `sshd` when the container starts.
- Document how to reopen the repo in the Dev Container and run acceptance tests.

## Verification

- `python3 -m json.tool .devcontainer/devcontainer.json`
- `git diff --check`
- `python - <<'PY' ... publish_doctree(Path('atest/README.rst').read_text()) ... PY`
- Config smoke assertions for required devcontainer/Dockerfile fields.
- Ad-hoc temporary verification script under `/tmp/hermes-verify-*`: checked devcontainer JSON, Dockerfile semantics, README instructions, LF endings, and diff whitespace.

I could not run a full local Docker/devcontainer build in this environment because the current user cannot access `/var/run/docker.sock`, and passwordless `sudo` is unavailable. The devcontainer files were validated syntactically and with focused static/ad-hoc checks against the issue requirements above.
